### PR TITLE
Add include directory

### DIFF
--- a/+fnirs1/installer/install.m
+++ b/+fnirs1/installer/install.m
@@ -91,7 +91,7 @@ fprintf(makefileid, 'LIB      := %s\n', LIB);
 fprintf(makefileid, 'LINK     := %s\n', LINK);
 fprintf(makefileid, 'OMPLINK  := %s\n\n', OMPLINK);
 fprintf(makefileid, 'all: $(OBJ)\n\t$(CXX) $(CXXFLAGS) $(OBJ) $(LIB) $(LINK) -o fnirsdlm\n\n');
-fprintf(makefileid, '$(OBJ): $(SRC)\n\t$(CXX) -c $(CXXFLAGS) $(SRC)\n\n');
+fprintf(makefileid, '$(OBJ): $(SRC)\n\t$(CXX) -c $(CXXFLAGS) $(INC) $(SRC)\n\n');
 fprintf(makefileid, '{OBJ}: cholesky.h randgen.h\n\n');
 fprintf(makefileid, 'clean:\n\trm -f fnirsdlm *.o\n');
 fclose(makefileid);


### PR DESCRIPTION
Currently, on our Linux installation, with FFTW available, we get

```
$ make
g++ -c -O3 main.cpp mcmc.cpp cholesky.cpp randgen.cpp mybspline.cpp hrf.cpp kernel_reg.cpp knots.cpp statistics.cpp config_info.cpp dlm.cpp
hrf.cpp:13:10: fatal error: fftw3.h: No such file or directory
 #include <fftw3.h>
          ^~~~~~~~~
compilation terminated.
make: *** [hrf.o] Error 1
```

This is because there isn't a `-I$FFTW_HOME` option on the compilation line.  Adding `$(INC)` fixes this issue.  If one is using the system package installer, this likely doesn't happen because `fftw3.h` will be in the default `CPATH`, whereas on many clusters, FFTW3 will be installed in a separate location making explicitly providing the right path required.  This also insures that the library and include paths are from the same version.